### PR TITLE
Add PVC to Knative serving and apps

### DIFF
--- a/knative-serving-app/Chart.yaml
+++ b/knative-serving-app/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: knative-serving-app
 description: A Helm chart for an app deployed using knative-serving
 type: application
-version: 0.1.0
+version: 0.1.1
 
 appVersion: 0.1.0

--- a/knative-serving-app/templates/knative-service.yaml
+++ b/knative-serving-app/templates/knative-service.yaml
@@ -15,16 +15,26 @@ spec:
       containerConcurrency: 1
       containers:
       - args:
-        {{- if .Values.extraArgs }}
-{{ toYaml .Values.extraArgs | indent 8 }}
+          {{- if .Values.extraArgs }}
+          {{ toYaml .Values.extraArgs | indent 10 }}
           {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         ports:
           {{- toYaml .Values.ports | nindent 10 }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+        volumeMounts:
+          {{- if .Values.volumeMounts }}
+          {{ toYaml .Values.volumeMounts | indent 10}}
+          {{- end }} 
       serviceAccountName: {{ include "serviceAccountName" . }}
       timeoutSeconds: 3600
+      volumes:
+        {{- if .Values.volumes }}
+        {{ toYaml .Values.volumes | indent 8 }}
+        {{- end }}
+        
+
   traffic:
   - latestRevision: true
     percent: 100

--- a/knative-serving-app/templates/knative-service.yaml
+++ b/knative-serving-app/templates/knative-service.yaml
@@ -10,13 +10,13 @@ spec:
   template:
     metadata:
       annotations:
-{{ toYaml .Values.service.annotations | nindent 8 }}
+        {{ toYaml .Values.service.annotations | nindent 8 }}
     spec:
       containerConcurrency: 1
       containers:
       - args:
           {{- if .Values.extraArgs }}
-          {{ toYaml .Values.extraArgs | indent 10 }}
+            {{ toYaml .Values.extraArgs | indent 10 }}
           {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         ports:
@@ -25,13 +25,13 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         volumeMounts:
           {{- if .Values.volumeMounts }}
-          {{ toYaml .Values.volumeMounts | indent 10}}
+            {{ toYaml .Values.volumeMounts | indent 10}}
           {{- end }} 
       serviceAccountName: {{ include "serviceAccountName" . }}
       timeoutSeconds: 3600
       volumes:
         {{- if .Values.volumes }}
-        {{ toYaml .Values.volumes | indent 8 }}
+          {{ toYaml .Values.volumes | indent 8 }}
         {{- end }}
         
 

--- a/knative-serving-app/templates/serviceaccount.yaml
+++ b/knative-serving-app/templates/serviceaccount.yaml
@@ -8,5 +8,5 @@ metadata:
     {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}
   labels:
-  {{ include "labels" . | nindent 4 }}
-  {{- end -}}
+    {{ include "labels" . | nindent 4 }}
+{{- end -}}

--- a/knative-serving/Chart.yaml
+++ b/knative-serving/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: knative-serving
 description: A Helm chart for knative-serving
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.11.0"
 sources:
   - https://github.com/knative/serving/releases/download/knative-v1.11.0/serving-crds.yaml

--- a/knative-serving/templates/serving-core.yaml
+++ b/knative-serving/templates/serving-core.yaml
@@ -5437,7 +5437,7 @@ data:
 
     # Default queue proxy resource requests and limits to good values for most cases if set.
     queueproxy.resource-defaults: "disabled"
-
+{{ .Values.configCoreFeatures | toYaml | indent 2}}
 ---
 
 # Copyright 2020 The Knative Authors

--- a/knative-serving/values.yaml
+++ b/knative-serving/values.yaml
@@ -4,7 +4,9 @@ gcConfig:
   max-non-active-revisions: "2"
 defaultConfig:
   max-revision-timeout-seconds: "3600"
-
+configCoreFeatures:
+  kubernetes.podspec-persistent-volume-claim: "enabled"
+  kubernetes.podspec-persistent-volume-write: "enabled"
 configIstio:
   example: |
     ################################


### PR DESCRIPTION
Enable PVC feature on `knative-serving` and add volumes/voulumeMounts to knative-apps templates.
Version has been incremented to avoid existing applications from being affected