### PR TITLE
Increase knative-serving netIstioController's memory request to match limit

### DIFF
--- a/knative-serving/values.yaml
+++ b/knative-serving/values.yaml
@@ -2028,7 +2028,7 @@ resources:
   netIstioController:
     requests:
       cpu: 30m
-      memory: 40Mi
+      memory: 400Mi
     limits:
       cpu: 300m
       memory: 400Mi


### PR DESCRIPTION
 Follow up for [this PR](https://github.com/cloudkite-io/helm-charts/pull/23)