### PR TITLE
Add matching label for certificate exporter service monitor

### DIFF
--- a/monitoring/values.yaml
+++ b/monitoring/values.yaml
@@ -52,6 +52,12 @@ version-checker:
     additionalLabels:
       release: "monitoring"
 
+x509-certificate-exporter:
+  prometheusServiceMonitor:
+    create: true
+    extraLabels:
+      release: "monitoring"
+      
 vpaApps:
   monitoring-kube-state-metrics:
     kind: Deployment


### PR DESCRIPTION
Prometheus uses a serviceMonitorSelector to select which serviceMonitors will be used for target discovery (to poll metrics from them). This PR updates the labels for the newly added certificate exporter to match Prometheus' selector labels