### PR TITLE
remove VPA for Prometheus CRD

### DIFF
--- a/monitoring/templates/vpa.yaml
+++ b/monitoring/templates/vpa.yaml
@@ -1,15 +1,63 @@
-{{- range $vpaAppName, $vpaAppConfig := .Values.vpaApps }}
+{{- with .Values.vpaApps.prometheus }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ $vpaAppName }}
+  name: prometheus-{{ $.Chart.Name }}-prometheus
 spec:
   targetRef:
     apiVersion: apps/v1
-    kind:       {{ $vpaAppConfig.kind }}
-    name:       {{ $vpaAppName }}
+    kind:       {{ .kind }}
+    name:       prometheus-{{ $.Chart.Name }}-prometheus
   updatePolicy:
-    updateMode: {{ $vpaAppConfig.mode }}
-    minReplicas: {{ $vpaAppConfig.minReplicas }}
+    updateMode: {{ .mode | default "Auto" }}
+    minReplicas: {{ .minReplicas | default "1" }}
 ---
 {{- end }}
+
+{{- with .Values.vpaApps.prometheus }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ $.Chart.Name }}-kube-state-metrics
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind:       {{ .kind }}
+    name:       {{ $.Chart.Name }}-kube-state-metrics
+  updatePolicy:
+    updateMode: {{ .mode | default "Auto" }}
+    minReplicas: {{ .minReplicas | default "1" }}
+---
+{{- end }}
+
+{{- with .Values.vpaApps.prometheus }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ $.Chart.Name }}-prometheus-node-exporter
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind:       {{ .kind }}
+    name:       {{ $.Chart.Name }}-prometheus-node-exporter
+  updatePolicy:
+    updateMode: {{ .mode | default "Auto" }}
+    minReplicas: {{ .minReplicas | default "1" }}
+---
+{{- end }}
+
+# {{- range $vpaAppName, $vpaAppConfig := .Values.vpaApps }}
+# apiVersion: autoscaling.k8s.io/v1
+# kind: VerticalPodAutoscaler
+# metadata:
+#   name: {{ $vpaAppName }}
+# spec:
+#   targetRef:
+#     apiVersion: apps/v1
+#     kind:       {{ $vpaAppConfig.kind }}
+#     name:       {{ $vpaAppName }}
+#   updatePolicy:
+#     updateMode: {{ $vpaAppConfig.mode }}
+#     minReplicas: {{ $vpaAppConfig.minReplicas }}
+# ---
+# {{- end }}

--- a/monitoring/templates/vpa.yaml
+++ b/monitoring/templates/vpa.yaml
@@ -1,63 +1,15 @@
-{{- with .Values.vpaApps.prometheus }}
+{{- range $vpaAppName, $vpaAppConfig := .Values.vpaApps }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: prometheus-{{ $.Chart.Name }}-prometheus
+  name: {{ if eq $vpaAppName "prometheus" }}{{ $vpaAppName }}-{{ $.Chart.Name }}-{{ $vpaAppName }}{{ else }}{{ $.Chart.Name }}-{{ $vpaAppName }}{{- end }}
 spec:
   targetRef:
     apiVersion: apps/v1
-    kind:       {{ .kind }}
-    name:       prometheus-{{ $.Chart.Name }}-prometheus
+    kind:       {{ $vpaAppConfig.kind }}
+    name:       {{ $.Chart.Name }}-{{ $vpaAppName }}
   updatePolicy:
-    updateMode: {{ .mode | default "Auto" }}
-    minReplicas: {{ .minReplicas | default "1" }}
+    updateMode: {{ $vpaAppConfig.mode | default "Auto" }}
+    minReplicas: {{ $vpaAppConfig.minReplicas | default "1" }}
 ---
 {{- end }}
-
-{{- with .Values.vpaApps.kube-state-metrics }}
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: {{ $.Chart.Name }}-kube-state-metrics
-spec:
-  targetRef:
-    apiVersion: apps/v1
-    kind:       {{ .kind }}
-    name:       {{ $.Chart.Name }}-kube-state-metrics
-  updatePolicy:
-    updateMode: {{ .mode | default "Auto" }}
-    minReplicas: {{ .minReplicas | default "1" }}
----
-{{- end }}
-
-{{- with .Values.vpaApps.prometheus-node-exporter }}
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: {{ $.Chart.Name }}-prometheus-node-exporter
-spec:
-  targetRef:
-    apiVersion: apps/v1
-    kind:       {{ .kind }}
-    name:       {{ $.Chart.Name }}-prometheus-node-exporter
-  updatePolicy:
-    updateMode: {{ .mode | default "Auto" }}
-    minReplicas: {{ .minReplicas | default "1" }}
----
-{{- end }}
-
-# {{- range $vpaAppName, $vpaAppConfig := .Values.vpaApps }}
-# apiVersion: autoscaling.k8s.io/v1
-# kind: VerticalPodAutoscaler
-# metadata:
-#   name: {{ $vpaAppName }}
-# spec:
-#   targetRef:
-#     apiVersion: apps/v1
-#     kind:       {{ $vpaAppConfig.kind }}
-#     name:       {{ $vpaAppName }}
-#   updatePolicy:
-#     updateMode: {{ $vpaAppConfig.mode }}
-#     minReplicas: {{ $vpaAppConfig.minReplicas }}
-# ---
-# {{- end }}

--- a/monitoring/templates/vpa.yaml
+++ b/monitoring/templates/vpa.yaml
@@ -14,7 +14,7 @@ spec:
 ---
 {{- end }}
 
-{{- with .Values.vpaApps.prometheus }}
+{{- with .Values.vpaApps.kube-state-metrics }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -30,7 +30,7 @@ spec:
 ---
 {{- end }}
 
-{{- with .Values.vpaApps.prometheus }}
+{{- with .Values.vpaApps.prometheus-node-exporter }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/monitoring/templates/vpa.yaml
+++ b/monitoring/templates/vpa.yaml
@@ -7,7 +7,7 @@ spec:
   targetRef:
     apiVersion: apps/v1
     kind:       {{ $vpaAppConfig.kind }}
-    name:       {{ $.Chart.Name }}-{{ $vpaAppName }}
+    name:       {{ if eq $vpaAppName "prometheus" }}{{ $vpaAppName }}-{{ $.Chart.Name }}-{{ $vpaAppName }}{{ else }}{{ $.Chart.Name }}-{{ $vpaAppName }}{{- end }}
   updatePolicy:
     updateMode: {{ $vpaAppConfig.mode | default "Auto" }}
     minReplicas: {{ $vpaAppConfig.minReplicas | default "1" }}

--- a/monitoring/values.yaml
+++ b/monitoring/values.yaml
@@ -10,35 +10,22 @@ kube-prometheus-stack:
         group_by: ['alertname', 'cluster', 'service', 'job']
     templateFiles:
       default_template.tmpl: |-
-          {{ define "cluster" }}{{ .ExternalURL | reReplaceAll ".*alertmanager\\.(.*)" "$1" }}{{ end }}
+        {{ define "cluster" }}{{ .ExternalURL | reReplaceAll ".*alertmanager\\.(.*)" "$1" }}{{ end }}
 
-          {{ define "msteams.ck.text" }}
-          {{- $root := . -}}
-          {{ range .Alerts -}}
-          *Alert:* {{ .Annotations.title }}{{ if .Labels.severity }} - `{{ .Labels.severity }}`{{ end }}
+        {{ define "msteams.ck.text" }}
+        {{- $root := . -}}
+        {{ range .Alerts -}}
+        *Severity:* `{{ .Labels.severity }}`
 
-          *Description:* {{ .Annotations.description }}
+        *Description:* {{ .Annotations.summary }}
 
-          *Details:*
-            {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
-            {{ end }}
-          {{ end }}
-          {{ end }}
+        *URL:* {{ .Annotations.query }}
+        {{ end }}
+        {{ end }}
 
-          {{ define "msteams.ck.title" }}
-          [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }} for {{ .CommonLabels.job }}
-          {{- if gt (len .CommonLabels) (len .GroupLabels) -}}
-            {{" "}}(
-            {{- with .CommonLabels.Remove .GroupLabels.Names }}
-              {{- range $index, $label := .SortedPairs -}}
-                {{ if $index }}, {{ end }}
-                {{- $label.Name }}="{{ $label.Value -}}"
-              {{- end }}
-            {{- end -}}
-            )
-          {{- end }}
-          {{ end }}
-
+        {{ define "msteams.ck.title" }}
+        [{{ .Status | toUpper }}{{ end }}] {{ .CommonLabels.alertname }}
+        {{ end }}
 
   prometheus:
     prometheusSpec:

--- a/monitoring/values.yaml
+++ b/monitoring/values.yaml
@@ -96,19 +96,10 @@ x509-certificate-exporter:
     create: false
       
 vpaApps:
-  monitoring-kube-state-metrics:
-    kind: Deployment
-    mode: Auto
-    minReplicas: 1
-  monitoring-prometheus-node-exporter:
-    kind: DaemonSet
-    mode: Auto
-    minReplicas: 2
-  version-checker:
-    kind: Deployment
-    mode: Auto
-    minReplicas: 1
-  prometheus-monitoring-kube-prometheus-prometheus:
+  prometheus:
     kind: StatefulSet
-    mode: Auto
-    minReplicas: 1
+  kube-state-metrics:
+    kind: Deployment
+  prometheus-node-exporter:
+    kind: DaemonSet
+    minReplicas: 2

--- a/version-checker/templates/vpa.yaml
+++ b/version-checker/templates/vpa.yaml
@@ -1,0 +1,12 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "version-checker.name" . }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind:       Deployment
+    name:       {{ include "version-checker.name" . }}
+  updatePolicy:
+    updateMode: Auto
+    minReplicas: 1


### PR DESCRIPTION
I've reworked VPA templates into more hardcoded versions due to the naming drift in case of different helm chart naming on the client end. The names we had before worked if `monitoring` was the name of the chart, but it didn't work for other names, like `kube-prometheus-stack` in IABBB. This change still allows to control them on the client end, but also removes the ability to add the new ones - we had some issues because of VPAs defined on both sides.