### PR TITLE
turn off solr query errors increase alert

### DIFF
--- a/prometheus-rules/templates/prometheusrules.solr.yaml
+++ b/prometheus-rules/templates/prometheusrules.solr.yaml
@@ -25,15 +25,15 @@ spec:
           labels:
             severity: critical
             instance: solr
-        - alert: SolrCloudQueryError
-          annotations:
-            summary: Solr query error
-            description: 'Solr has increased query errors in collection {{ "{{" }} $labels.collection }} for replica {{ "{{" }} $labels.replica }} on {{ "{{" }} $labels.base_url }}.'
-          expr: 'increase(solr_metrics_core_errors_total{category="QUERY"}[1m]) > 1'
-          for: 5m
-          labels:
-            severity: warning
-            instance: solr
+        # - alert: SolrCloudQueryError
+        #   annotations:
+        #     summary: Solr query error
+        #     description: 'Solr has increased query errors in collection {{ "{{" }} $labels.collection }} for replica {{ "{{" }} $labels.replica }} on {{ "{{" }} $labels.base_url }}.'
+        #   expr: 'increase(solr_metrics_core_errors_total{category="QUERY"}[1m]) > 1'
+        #   for: 5m
+        #   labels:
+        #     severity: warning
+        #     instance: solr
         - alert: SolrCloudReplicationError
           annotations:
             summary: Solr replication error


### PR DESCRIPTION
This alert is constantly triggered by the same `Client exception` errors that Justin asked us to filter out (which we did).
We don't really need it since we already have similar one in loki-stack.