### PR TITLE
monitoring: change version-checker dependency to official repo chart

### DIFF
--- a/monitoring/Chart.yaml
+++ b/monitoring/Chart.yaml
@@ -2,16 +2,16 @@ apiVersion: v2
 name: monitoring
 description: Helm chart for Prometheus
 type: application
-version: 0.3.2
+version: 0.3.3
 dependencies:
 - name: kube-prometheus-stack
   version: 58.3.1
   appVersion: v0.73.2
   repository: https://prometheus-community.github.io/helm-charts
 - name: version-checker
-  version: 0.1.0
-  appVersion: v0.2.1
-  repository: oci://us-central1-docker.pkg.dev/cloudkite-public/public-helm-charts
+  version: v0.8.2
+  appVersion: v0.8.2
+  repository: https://charts.jetstack.io
 - name: x509-certificate-exporter
   version: 3.12.0
   appVersion: 3.12.0

--- a/monitoring/values.yaml
+++ b/monitoring/values.yaml
@@ -71,6 +71,7 @@ kube-prometheus-stack:
 #   password: PASSWORD
 
 version-checker:
+  replicaCount: 1
   additionalAnnotations: {}
   additionalLabels: {}
   acr:
@@ -90,13 +91,18 @@ version-checker:
     token:
   gcr:
     token:
-
+  env: {}
+  selfhosted: []
+  resources: {}
   versionChecker:
     logLevel: info
     metricsServingAddress: 0.0.0.0:8080
     testAllContainers: true
     imageCacheTimeout: 30m
-
+  service:
+    annotations: {}
+    labels: {}
+    port: 8080
   serviceMonitor:
     enabled: true
     additionalLabels:

--- a/monitoring/values.yaml
+++ b/monitoring/values.yaml
@@ -71,6 +71,32 @@ kube-prometheus-stack:
 #   password: PASSWORD
 
 version-checker:
+  additionalAnnotations: {}
+  additionalLabels: {}
+  acr:
+    username:
+    password:
+    refreshToken:
+  docker:
+    username:
+    password:
+    token:
+  ecr:
+    accessKeyID:
+    secretAccessKey:
+    sessionToken:
+    iamRoleArn:
+  quay:
+    token:
+  gcr:
+    token:
+
+  versionChecker:
+    logLevel: info
+    metricsServingAddress: 0.0.0.0:8080
+    testAllContainers: true
+    imageCacheTimeout: 30m
+
   serviceMonitor:
     enabled: true
     additionalLabels:


### PR DESCRIPTION
Update version-checker to use official repo chart to take advantage of ongoing fixes

https://github.com/jetstack/version-checker/tree/main/deploy/charts/version-checker 

TASK: https://app.clickup.com/t/8669xnkpj