### PR TITLE
deprecate custom tailscale helm chart in favor of the official one

### DIFF
--- a/tailscale/Chart.yaml
+++ b/tailscale/Chart.yaml
@@ -15,10 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "1.16.0"
+deprecated: true

--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -1,0 +1,1 @@
+⚠️ **This chart is deprecated**: This Helm chart is no longer maintained and is deprecated in favor of the official Tailscale k8s-operator https://tailscale.com/kb/1236/kubernetes-operator#setup.


### PR DESCRIPTION
Deprecating in favor of this official k8s-operator helm chart https://tailscale.com/kb/1236/kubernetes-operator#setup