### PR TITLE
Enable or Disable VPA resources creation

### DIFF
--- a/monitoring/Chart.yaml
+++ b/monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: monitoring
 description: Helm chart for Prometheus
 type: application
-version: 0.3.3
+version: 0.4.0
 dependencies:
 - name: kube-prometheus-stack
   version: 58.3.1

--- a/monitoring/templates/vpa.yaml
+++ b/monitoring/templates/vpa.yaml
@@ -1,4 +1,5 @@
-{{- range $vpaAppName, $vpaAppConfig := .Values.vpaApps }}
+{{- if .Values.vpaApps.enabled }}
+{{- range $vpaAppName, $vpaAppConfig := .Values.vpaApps.configs }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -12,4 +13,5 @@ spec:
     updateMode: {{ $vpaAppConfig.mode | default "Auto" }}
     minReplicas: {{ $vpaAppConfig.minReplicas | default "1" }}
 ---
+{{- end }}
 {{- end }}

--- a/monitoring/values.yaml
+++ b/monitoring/values.yaml
@@ -117,10 +117,12 @@ x509-certificate-exporter:
     create: false
       
 vpaApps:
-  prometheus:
-    kind: StatefulSet
-  kube-state-metrics:
-    kind: Deployment
-  prometheus-node-exporter:
-    kind: DaemonSet
-    minReplicas: 2
+  enabled: true
+  configs:
+    prometheus:
+      kind: StatefulSet
+    kube-state-metrics:
+      kind: Deployment
+    prometheus-node-exporter:
+      kind: DaemonSet
+      minReplicas: 2


### PR DESCRIPTION
Some newly created clusters do not have the VPA API configuration set up. Enabling VPA by default should not be the standard behavior. Instead, users should have the flexibility to enable or disable VPA resource creation based on their cluster requirements.