### PR TITLE
Make secrets optional for custom mutating webhook

### DIFF
--- a/custom-mutating-webhook/templates/secret.yaml
+++ b/custom-mutating-webhook/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.secrets.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,4 +8,4 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.secrets.tls_crt}}
   tls.key: {{ .Values.secrets.tls_key}}
-
+{{- end }}

--- a/custom-mutating-webhook/values.yaml
+++ b/custom-mutating-webhook/values.yaml
@@ -2,6 +2,11 @@ replicas: 1
 
 namespace: webhooks
 
+secrets:
+  create: false # Indicates if the secret should be created (can be false if the secret already exists)
+  tls_crt: ""
+  tls_key: ""
+
 tolerations: []
 
 webhook:


### PR DESCRIPTION
This PR:
- Make secrets in mutating webhook chart optional if already exists.